### PR TITLE
Multi-module fixed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
@@ -24,6 +24,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 
 /**
  * @author edward
@@ -71,15 +74,30 @@ public class PitBuildAction implements HealthReportingAction, StaplerProxy {
     Map<String, MutationReport> reports = new HashMap<String, MutationReport>();
 
     try {
-      FilePath[] files = new FilePath(owner_.getRootDir()).list("mutation-report*/mutations.xml");
+      FilePath[] files = new FilePath(owner_.getRootDir()).list("mutation-report-*/mutations.xml");
 
       if (files.length < 1) {
-        logger.log(Level.WARNING, "Could not find mutation-report*/mutations.xml in " + owner_.getRootDir());
+        logger.log(Level.WARNING, "Could not find mutation-report-*/mutations.xml in " + owner_.getRootDir());
       }
 
       for (int i = 0; i < files.length; i++) {
         logger.log(Level.WARNING, "Creating report for file: " + files[i].getRemote());
-        reports.put(String.valueOf(i), MutationReport.create(files[i].read()));
+        
+        final String pattern = ".*mutation-report-([^/]*).*";
+        Pattern r = Pattern.compile(pattern);
+        
+        String name = "";
+        
+        Matcher m = r.matcher(files[i].getRemote());
+        if (m.find()) 
+        {
+        	name = m.group(1);
+        }
+        else
+        {
+        	name = String.valueOf(i);
+        }
+        reports.put(name, MutationReport.create(files[i].read()));
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
@@ -56,7 +56,7 @@ public class PitPublisher extends Recorder {
 
       ParseReportCallable fileCallable = new ParseReportCallable(mutationStatsFile_);
       FilePath[] reports = moduleRoot.act(fileCallable);
-      publishReports(reports, new FilePath(build.getRootDir()));
+      publishReports(reports, new FilePath(build.getRootDir()), build.getModuleRoot().getRemote());
 
       //publish latest reports
       PitBuildAction action = new PitBuildAction(build);
@@ -74,12 +74,14 @@ public class PitPublisher extends Recorder {
     return new PitProjectAction(project);
   }
 
-  void publishReports(FilePath[] reports, FilePath buildTarget) {
+  void publishReports(FilePath[] reports, FilePath buildTarget, final String base) {
     for (int i = 0; i < reports.length; i++) {
       FilePath report = reports[i];
       listener_.getLogger().println("Publishing mutation report: " + report.getRemote());
-
-      final FilePath targetPath = new FilePath(buildTarget, "mutation-report" + (i == 0 ? "" : i));
+      
+      final String moduleName = report.getRemote().replace(base, "").split("/")[1];
+            
+      final FilePath targetPath = new FilePath(buildTarget, "mutation-report-" + moduleName);
       try {
         reports[i].getParent().copyRecursiveTo(targetPath);
       } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClass.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClass.java
@@ -46,7 +46,7 @@ public class MutatedClass extends MutationResult<MutatedClass> {
 
   public String getSourceFileContent() {
     try {
-      return new TextFile(new File(getOwner().getRootDir(), "mutation-report/" + package_ + File.separator + fileName_)).read();
+      return new TextFile(new File(getOwner().getRootDir(), "mutation-report-" + getParent().getParent().getName() + "/" + package_ + File.separator + fileName_)).read();
     }
     catch (IOException exception) {
       return "Could not read source file: " + getOwner().getRootDir().getPath()


### PR DESCRIPTION
Fixed the link to the source page in the class view when using more
than one module.

Now the modules are named after their root folder instead of an id
